### PR TITLE
fix: ensure informers are running

### DIFF
--- a/hack/mock/cluster.yaml
+++ b/hack/mock/cluster.yaml
@@ -23,46 +23,46 @@ spec:
   controlPlaneEndpoint:
     host: 127.0.0.1
     port: 6443
----
-apiVersion: cluster.x-k8s.io/v1alpha3
-kind: Machine
-metadata:
-  labels:
-    cluster.x-k8s.io/cluster-name: example
-    cluster.x-k8s.io/control-plane: 'true'
-  name: example-0
-spec:
-  clusterName: example
-  bootstrap:
-    configRef:
-      apiVersion: bootstrap.cluster.x-k8s.io/v1alpha3
-      kind: TalosConfig
-      name: example-0
-  infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
-    kind: MetalMachine
-    name: example-0
-  version: 1.18.2
----
-apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
-kind: MetalMachine
-metadata:
-  name: example-0
-spec:
-  serverRef:
-    apiVersion: metal.arges.dev/v1alpha1
-    kind: Server
-    name: 00000000-0000-0000-0000-012345678912
-  bmc:
-    endpoint: 127.0.0.1
-    user: admin
-    pass: admin
----
-apiVersion: bootstrap.cluster.x-k8s.io/v1alpha3
-kind: TalosConfig
-metadata:
-  name: example-0
-  labels:
-    cluster.x-k8s.io/cluster-name: example
-spec:
-  generateType: init
+# ---
+# apiVersion: cluster.x-k8s.io/v1alpha3
+# kind: Machine
+# metadata:
+#   labels:
+#     cluster.x-k8s.io/cluster-name: example
+#     cluster.x-k8s.io/control-plane: 'true'
+#   name: example-0
+# spec:
+#   clusterName: example
+#   bootstrap:
+#     configRef:
+#       apiVersion: bootstrap.cluster.x-k8s.io/v1alpha3
+#       kind: TalosConfig
+#       name: example-0
+#   infrastructureRef:
+#     apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
+#     kind: MetalMachine
+#     name: example-0
+#   version: 1.18.2
+# ---
+# apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
+# kind: MetalMachine
+# metadata:
+#   name: example-0
+# spec:
+#   serverRef:
+#     apiVersion: metal.arges.dev/v1alpha1
+#     kind: Server
+#     name: 00000000-0000-0000-0000-012345678912
+#   bmc:
+#     endpoint: 127.0.0.1
+#     user: admin
+#     pass: admin
+# ---
+# apiVersion: bootstrap.cluster.x-k8s.io/v1alpha3
+# kind: TalosConfig
+# metadata:
+#   name: example-0
+#   labels:
+#     cluster.x-k8s.io/cluster-name: example
+# spec:
+#   generateType: init


### PR DESCRIPTION
We need to ensure that we wait on the cache stop channel so that the
informers can send events.