### PR TITLE
feat: show cluster machines

### DIFF
--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -9,7 +9,6 @@ import Inventory from "@/views/Inventory.vue";
 import InventorySidebar from "@/components/InventorySidebar.vue";
 import Servers from "@/views/Servers.vue";
 import ServerClasses from "@/views/ServerClasses.vue";
-import Toolbar from "@/components/Toolbar.vue";
 import Machines from "@/views/Machines.vue";
 import Pools from "@/views/Pools.vue";
 import NewCluster from "@/views/NewCluster.vue";
@@ -26,7 +25,6 @@ const routes = [
   {
     path: "/inventory",
     name: "inventory",
-    component: Inventory,
     components: {
       default: Inventory,
       sidebar: InventorySidebar,
@@ -48,7 +46,6 @@ const routes = [
     path: "/clusters",
     components: {
       default: Clusters,
-      toolbar: Toolbar,
     },
   },
   {
@@ -61,12 +58,12 @@ const routes = [
     },
     children: [
       {
-        path: "/machines",
+        path: "machines",
         name: "machines",
         component: Machines,
       },
       {
-        path: "/pools",
+        path: "pools",
         name: "pools",
         component: Pools,
       },

--- a/frontend/src/views/Machines.vue
+++ b/frontend/src/views/Machines.vue
@@ -41,6 +41,14 @@ export default Vue.extend({
     return {
       items: []
     };
+  },
+
+  mounted: function() {
+    window.backend.Machines.Machines(this.$route.params.cluster).then(
+      machines => {
+        this.items = machines;
+      }
+    );
   }
 });
 </script>

--- a/frontend/src/views/ServerClasses.vue
+++ b/frontend/src/views/ServerClasses.vue
@@ -29,7 +29,7 @@
 import Vue from "vue";
 
 export default Vue.extend({
-  name: "Inventory",
+  name: "ServerClasses",
 
   data() {
     return {

--- a/frontend/src/views/Servers.vue
+++ b/frontend/src/views/Servers.vue
@@ -31,7 +31,7 @@
 import Vue from "vue";
 
 export default Vue.extend({
-  name: "Inventory",
+  name: "Servers",
 
   data() {
     return {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module ui
+module github.com/talos-systems/ui
 
 go 1.14
 

--- a/main.go
+++ b/main.go
@@ -6,10 +6,11 @@ package main
 
 import (
 	"log"
-	"ui/pkg/backend"
 
 	"github.com/leaanthony/mewn"
 	"github.com/wailsapp/wails"
+
+	"github.com/talos-systems/ui/pkg/backend"
 )
 
 func main() {
@@ -32,5 +33,6 @@ func main() {
 	app.Bind(b.Kubernetes.Clusters)
 	app.Bind(b.Kubernetes.Servers)
 	app.Bind(b.Kubernetes.ServerClasses)
+	app.Bind(b.Kubernetes.Machines)
 	app.Run()
 }

--- a/pkg/backend/clusters.go
+++ b/pkg/backend/clusters.go
@@ -14,7 +14,7 @@ import (
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/scale/scheme"
 	toolscache "k8s.io/client-go/tools/cache"
-	"sigs.k8s.io/cluster-api/api/v1alpha2"
+	"sigs.k8s.io/cluster-api/api/v1alpha3"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 )
 
@@ -22,7 +22,7 @@ type Clusters struct {
 	config *rest.Config
 	log    *wails.CustomLogger
 
-	clusters []*v1alpha2.Cluster
+	clusters []*v1alpha3.Cluster
 
 	sync.Mutex
 }
@@ -30,7 +30,7 @@ type Clusters struct {
 func (c *Clusters) WailsInit(runtime *wails.Runtime) error {
 	c.log = runtime.Log.New("Clusters")
 
-	ch := make(chan []*v1alpha2.Cluster, 100)
+	ch := make(chan []*v1alpha3.Cluster, 100)
 
 	go func() {
 		err := c.watch(ch)
@@ -54,24 +54,24 @@ func (c *Clusters) WailsInit(runtime *wails.Runtime) error {
 	return nil
 }
 
-func (c *Clusters) Clusters() []*v1alpha2.Cluster {
+func (c *Clusters) Clusters() []*v1alpha3.Cluster {
 	c.Lock()
 	defer c.Unlock()
 
 	return c.clusters
 }
 
-func (c *Clusters) watch(ch chan []*v1alpha2.Cluster) error {
+func (c *Clusters) watch(ch chan []*v1alpha3.Cluster) error {
 	s := runtime.NewScheme()
 	_ = scheme.AddToScheme(s)
-	_ = v1alpha2.AddToScheme(s)
+	_ = v1alpha3.AddToScheme(s)
 
 	cache, err := cache.New(c.config, cache.Options{Scheme: s})
 	if err != nil {
 		return err
 	}
 
-	informer, err := cache.GetInformer(context.TODO(), &v1alpha2.Cluster{})
+	informer, err := cache.GetInformer(context.TODO(), &v1alpha3.Cluster{})
 	if err != nil {
 		return err
 	}
@@ -81,7 +81,7 @@ func (c *Clusters) watch(ch chan []*v1alpha2.Cluster) error {
 			c.Lock()
 			defer c.Unlock()
 
-			cluster := obj.(*v1alpha2.Cluster)
+			cluster := obj.(*v1alpha3.Cluster)
 
 			// TODO(andrewrynhard): Remove this once we figure out why these
 			// fields are causing the JSON decoder on the frontend to fail.
@@ -96,7 +96,7 @@ func (c *Clusters) watch(ch chan []*v1alpha2.Cluster) error {
 			c.Lock()
 			defer c.Unlock()
 
-			cluster := newObj.(*v1alpha2.Cluster)
+			cluster := newObj.(*v1alpha3.Cluster)
 
 			for i, old := range c.clusters {
 				if old.UID == cluster.UID {
@@ -117,7 +117,7 @@ func (c *Clusters) watch(ch chan []*v1alpha2.Cluster) error {
 			c.Lock()
 			defer c.Unlock()
 
-			cluster := obj.(*v1alpha2.Cluster)
+			cluster := obj.(*v1alpha3.Cluster)
 
 			for i, old := range c.clusters {
 				if old.UID == cluster.UID {


### PR DESCRIPTION
This hooks up the machines backend with the front end. Now,
when a user clicks on the machine link for a cluster, a list
of machines that belong to that cluster are shown.