### PR TITLE
feat: default cluster view to machines

### DIFF
--- a/frontend/src/views/Clusters.vue
+++ b/frontend/src/views/Clusters.vue
@@ -59,7 +59,7 @@ export default Vue.extend({
 
   methods: {
     click(item) {
-      router.push(`/clusters/${item.metadata.name}`);
+      router.push(`/clusters/${item.metadata.name}/machines`);
     }
   }
 });


### PR DESCRIPTION
When clicking on a cluster, show the machines.